### PR TITLE
Make LOCALSTACK_HOST static

### DIFF
--- a/src/Aspire.Hosting.LocalStack/Internal/LocalStackConnectionStringAvailableCallback.cs
+++ b/src/Aspire.Hosting.LocalStack/Internal/LocalStackConnectionStringAvailableCallback.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using Aspire.Hosting.ApplicationModel;
+﻿using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CloudFormation;
 using Aspire.Hosting.LocalStack.Annotations;
 
@@ -37,9 +36,6 @@ internal static class LocalStackConnectionStringAvailableCallback
             }
 
             var localStackUrl = new Uri(connectionString);
-
-            var resourceBuilder = builder.CreateResourceBuilder(localStackResource);
-            resourceBuilder.WithEnvironment("LOCALSTACK_HOST", $"{localStackUrl.Host}:{localStackUrl.Port.ToString(CultureInfo.InvariantCulture)}");
 
             var referencedResources = localStackResource.Annotations.OfType<LocalStackReferenceAnnotation>();
             foreach (var resource in referencedResources.Select(annotation => annotation.Resource))

--- a/src/Aspire.Hosting.LocalStack/LocalStackResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.LocalStack/LocalStackResourceBuilderExtensions.cs
@@ -176,6 +176,7 @@ public static class LocalStackResourceBuilderExtensions
             .WithEnvironment("DEBUG", containerOptions.DebugLevel.ToString(CultureInfo.InvariantCulture))
             .WithEnvironment("LS_LOG", containerOptions.LogLevel.ToEnvironmentValue())
             .WithEnvironment("DOCKER_HOST", "unix:///var/run/docker.sock")
+            .WithEnvironment("LOCALSTACK_HOST", $"localhost:{Constants.DefaultContainerPort.ToString(CultureInfo.InvariantCulture)}")
             .WithExternalHttpEndpoints()
             .ExcludeFromManifest(); // LocalStack is for local development only
 


### PR DESCRIPTION
Fixes #13 

My understanding is that the hostname localstack should be using should be consistent with it's external endpoint, so I _think_ this change makes sense.