### PR TITLE
docs(agents): add lightweight agent harness guidance

### DIFF
--- a/.claude/skills/aspire-source-navigation/SKILL.md
+++ b/.claude/skills/aspire-source-navigation/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: aspire-source-navigation
+description: Use when working on Aspire.Hosting.LocalStack source compatibility, Aspire/AWS/LocalStack package internals, Directory.Packages.props version bumps, or AddLocalStack/UseLocalStack/WithReference behavior.
+---
+
+# Aspire Source Navigation
+
+Canonical skill content lives in [docs/agents/skills/aspire-source-navigation.md](../../../docs/agents/skills/aspire-source-navigation.md).
+
+Read that file and follow it. This file is a native Claude Code discovery relay, not the source of truth.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# GitHub Copilot Instructions
+
+Read `AGENTS.md` first. It is the canonical repository contract for this project.
+
+Harness-specific files are relays, not policy sources. The project-specific Aspire source navigation skill is documented in `docs/agents/skills/aspire-source-navigation.md` and exposed to Copilot Agent Skills through `.github/skills/aspire-source-navigation/SKILL.md`.

--- a/.github/skills/aspire-source-navigation/SKILL.md
+++ b/.github/skills/aspire-source-navigation/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: aspire-source-navigation
+description: Use when working on Aspire.Hosting.LocalStack source compatibility, Aspire/AWS/LocalStack package internals, Directory.Packages.props version bumps, or AddLocalStack/UseLocalStack/WithReference behavior.
+---
+
+# Aspire Source Navigation
+
+Canonical skill content lives in [docs/agents/skills/aspire-source-navigation.md](../../../docs/agents/skills/aspire-source-navigation.md).
+
+Read that file and follow it. This file is a GitHub Copilot / VS Code Agent Skills discovery relay, not the source of truth.

--- a/.gitignore
+++ b/.gitignore
@@ -420,4 +420,10 @@ FodyWeavers.xsd
 .idea/
 internal-docs/
 
+.claude/*
+!.claude/skills/
+!.claude/skills/**
+
+external/
+
 .fake

--- a/.gitignore
+++ b/.gitignore
@@ -396,14 +396,6 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
-# VS Code files for those working on multiple tools
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
-
 # Local History for Visual Studio Code
 .history/
 
@@ -420,6 +412,7 @@ FodyWeavers.xsd
 .idea/
 internal-docs/
 
+.vscode/
 .claude/*
 !.claude/skills/
 !.claude/skills/**
@@ -427,3 +420,9 @@ internal-docs/
 external/
 
 .fake
+
+.mcp.active
+.mcp.claude.json
+.mcp.copilot-cli.json
+.mcp.json
+opencode.jsonc

--- a/.opencode/skills/aspire-source-navigation/SKILL.md
+++ b/.opencode/skills/aspire-source-navigation/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: aspire-source-navigation
+description: Use when working on Aspire.Hosting.LocalStack source compatibility, Aspire/AWS/LocalStack package internals, Directory.Packages.props version bumps, or AddLocalStack/UseLocalStack/WithReference behavior.
+---
+
+# Aspire Source Navigation
+
+Canonical skill content lives in [docs/agents/skills/aspire-source-navigation.md](../../../docs/agents/skills/aspire-source-navigation.md).
+
+Read that file and follow it. This file is a native OpenCode discovery relay, not the source of truth.
+
+OpenCode loads project skills at session start. Restart OpenCode after changing this file if the running UI needs the updated skill.

--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,0 +1,296 @@
+{
+  "version": 1,
+  "createdAt": "2026-06-19T07:04:36.9517037+00:00",
+  "updatedAt": "2026-06-19T07:04:36.9543258+00:00",
+  "description": "Initial baseline created by 'slopwatch init' on 2026-06-19 07:04:36 UTC",
+  "entries": [
+    {
+      "hash": "1f088b1f66fefc4b",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Analyzer/Function.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable CA1822 // Member 'FunctionHandler' does not access instance data and can be marked as static",
+      "message": "#pragma warning disable for warnings CA1822 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.954152+00:00"
+    },
+    {
+      "hash": "2c6e169bedd741ea",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Analyzer/Function.cs",
+      "lineNumber": 2,
+      "codeSnippet": "#pragma warning disable S2325 // Make 'FunctionHandler' a static method.",
+      "message": "#pragma warning disable for warnings S2325 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542399+00:00"
+    },
+    {
+      "hash": "14edd7195c39766c",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Analyzer/Function.cs",
+      "lineNumber": 3,
+      "codeSnippet": "#pragma warning disable CA1812 // Error CA1812 : 'Function.ShortenRequest' is an internal class that is apparently never instantiated.",
+      "message": "#pragma warning disable for warnings CA1812 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542441+00:00"
+    },
+    {
+      "hash": "87bc67cb907132fe",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Analyzer/Function.cs",
+      "lineNumber": 4,
+      "codeSnippet": "#pragma warning disable CA1031 // Modify 'FunctionHandler' to catch a more specific allowed exception type, or rethrow the exception",
+      "message": "#pragma warning disable for warnings CA1031 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542464+00:00"
+    },
+    {
+      "hash": "a9216bb1ec8d305f",
+      "ruleId": "SW005",
+      "filePath": "playground/lambda/LocalStack.Lambda.AppHost/LocalStack.Lambda.AppHost.csproj",
+      "lineNumber": 8,
+      "codeSnippet": "<NoWarn>$(NoWarn);CS8002;ASPIRE004</NoWarn>",
+      "message": "Adding warnings to NoWarn: CS8002;ASPIRE004",
+      "baselinedAt": "2026-06-19T07:04:36.954251+00:00"
+    },
+    {
+      "hash": "478e0247f179000d",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.AppHost/Program.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable CA2252 // Using 'AddAWSLambdaFunction' requires opting into preview features.",
+      "message": "#pragma warning disable for warnings CA2252 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542538+00:00"
+    },
+    {
+      "hash": "0d40e68102934cba",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.AppHost/UrlShortenerStack.cs",
+      "lineNumber": 5,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.954256+00:00"
+    },
+    {
+      "hash": "5174ec66ba7a1b3c",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Redirector/Function.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable CA1822 // Member 'FunctionHandler' does not access instance data and can be marked as static",
+      "message": "#pragma warning disable for warnings CA1822 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542584+00:00"
+    },
+    {
+      "hash": "cc997c27b5ace64c",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Redirector/Function.cs",
+      "lineNumber": 2,
+      "codeSnippet": "#pragma warning disable S2325 // Make 'FunctionHandler' a static method.",
+      "message": "#pragma warning disable for warnings S2325 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542606+00:00"
+    },
+    {
+      "hash": "3d34c0205e09b71f",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Redirector/Function.cs",
+      "lineNumber": 3,
+      "codeSnippet": "#pragma warning disable CA1812 // Error CA1812 : 'Function.ShortenRequest' is an internal class that is apparently never instantiated.",
+      "message": "#pragma warning disable for warnings CA1812 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542636+00:00"
+    },
+    {
+      "hash": "7b7b7e8aa27b22fb",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.Redirector/Function.cs",
+      "lineNumber": 4,
+      "codeSnippet": "#pragma warning disable CA1031 // Modify 'FunctionHandler' to catch a more specific allowed exception type, or rethrow the exception",
+      "message": "#pragma warning disable for warnings CA1031 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542655+00:00"
+    },
+    {
+      "hash": "3ed3dcd5f08718d2",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.UrlShortener/Function.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable CA1822 // Member 'FunctionHandler' does not access instance data and can be marked as static",
+      "message": "#pragma warning disable for warnings CA1822 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542682+00:00"
+    },
+    {
+      "hash": "8972d0cdc07febaa",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.UrlShortener/Function.cs",
+      "lineNumber": 2,
+      "codeSnippet": "#pragma warning disable S2325 // Make 'FunctionHandler' a static method.",
+      "message": "#pragma warning disable for warnings S2325 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542701+00:00"
+    },
+    {
+      "hash": "9ca64a123b71f79a",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.UrlShortener/Function.cs",
+      "lineNumber": 3,
+      "codeSnippet": "#pragma warning disable CA1812 // Error CA1812 : 'Function.ShortenRequest' is an internal class that is apparently never instantiated.",
+      "message": "#pragma warning disable for warnings CA1812 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542726+00:00"
+    },
+    {
+      "hash": "5066bd8c9d9336f0",
+      "ruleId": "SW002",
+      "filePath": "playground/lambda/LocalStack.Lambda.UrlShortener/Function.cs",
+      "lineNumber": 4,
+      "codeSnippet": "#pragma warning disable CA1031 // Modify 'FunctionHandler' to catch a more specific allowed exception type, or rethrow the exception",
+      "message": "#pragma warning disable for warnings CA1031 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542745+00:00"
+    },
+    {
+      "hash": "86dc29152102e8a0",
+      "ruleId": "SW002",
+      "filePath": "playground/LocalStack.Playground.ServiceDefaults/LocalStackPlaygroundExtensions.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.954277+00:00"
+    },
+    {
+      "hash": "fa53b2e1135044cd",
+      "ruleId": "SW002",
+      "filePath": "playground/provisioning/LocalStack.Provisioning.CDK.AppHost/CustomStack.cs",
+      "lineNumber": 5,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542798+00:00"
+    },
+    {
+      "hash": "8f788ee0aba3813d",
+      "ruleId": "SW005",
+      "filePath": "playground/provisioning/LocalStack.Provisioning.CDK.AppHost/LocalStack.Provisioning.CDK.AppHost.csproj",
+      "lineNumber": 8,
+      "codeSnippet": "<NoWarn>$(NoWarn);CS8002</NoWarn>",
+      "message": "Adding warnings to NoWarn: CS8002",
+      "baselinedAt": "2026-06-19T07:04:36.9542824+00:00"
+    },
+    {
+      "hash": "303586651803b1f4",
+      "ruleId": "SW005",
+      "filePath": "playground/provisioning/LocalStack.Provisioning.CloudFormation.AppHost/LocalStack.Provisioning.CloudFormation.AppHost.csproj",
+      "lineNumber": 8,
+      "codeSnippet": "<NoWarn>$(NoWarn);CS8002</NoWarn>",
+      "message": "Adding warnings to NoWarn: CS8002",
+      "baselinedAt": "2026-06-19T07:04:36.9542848+00:00"
+    },
+    {
+      "hash": "a2b041588ff4f75b",
+      "ruleId": "SW002",
+      "filePath": "playground/provisioning/LocalStack.Provisioning.Frontend/Handlers/ChatMessageHandler.cs",
+      "lineNumber": 5,
+      "codeSnippet": "#pragma warning disable CA1848 // Use the LoggerMessage delegates",
+      "message": "#pragma warning disable for warnings CA1848 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542872+00:00"
+    },
+    {
+      "hash": "013b3eaea362797b",
+      "ruleId": "SW002",
+      "filePath": "playground/provisioning/LocalStack.Provisioning.Frontend/Handlers/ChatMessageHandler.cs",
+      "lineNumber": 6,
+      "codeSnippet": "#pragma warning disable CA1812 // Mark members as static",
+      "message": "#pragma warning disable for warnings CA1812 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542892+00:00"
+    },
+    {
+      "hash": "7f5bdf73a7710c05",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/LocalStackCloudFormationResourceExtensions.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.954292+00:00"
+    },
+    {
+      "hash": "aa926463c314649f",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/LocalStackProjectExtensions.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542941+00:00"
+    },
+    {
+      "hash": "77e436f7acb94908",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/LocalStackResource.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542962+00:00"
+    },
+    {
+      "hash": "d1ebdb370c2a4d52",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/LocalStackResourceBuilderExtensions.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9542982+00:00"
+    },
+    {
+      "hash": "55861de754de7302",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/CDK/CdkBootstrapManager.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130, MA0045",
+      "message": "#pragma warning disable for warnings IDE0130, MA0045 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9543002+00:00"
+    },
+    {
+      "hash": "bc631ef13ed5bae2",
+      "ruleId": "SW002",
+      "filePath": "src/Aspire.Hosting.LocalStack/Container/LocalStackContainerOptions.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable IDE0130",
+      "message": "#pragma warning disable for warnings IDE0130 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9543034+00:00"
+    },
+    {
+      "hash": "8b1dcfb8dff5c7cd",
+      "ruleId": "SW005",
+      "filePath": "tests/Directory.Build.props",
+      "lineNumber": 7,
+      "codeSnippet": "<NoWarn>$(NoWarn);CA1515;CA2007;IDE1006;CA1707</NoWarn>",
+      "message": "Adding warnings to NoWarn: CA1515;CA2007;IDE1006;CA1707",
+      "baselinedAt": "2026-06-19T07:04:36.9543054+00:00"
+    },
+    {
+      "hash": "6b7a8edc69ac89be",
+      "ruleId": "SW005",
+      "filePath": "tests/Aspire.Hosting.LocalStack.Integration.Tests/Aspire.Hosting.LocalStack.Integration.Tests.csproj",
+      "lineNumber": 9,
+      "codeSnippet": "<NoWarn>$(NoWarn);CA2007;CA1515;CA5399</NoWarn>",
+      "message": "Adding warnings to NoWarn: CA2007;CA1515;CA5399",
+      "baselinedAt": "2026-06-19T07:04:36.9543081+00:00"
+    },
+    {
+      "hash": "855e6606eb2e7bf7",
+      "ruleId": "SW004",
+      "filePath": "tests/Aspire.Hosting.LocalStack.Integration.Tests/Playground/Lambda/LocalStackLambdaFunctionalTests.cs",
+      "lineNumber": 131,
+      "codeSnippet": "Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)",
+      "message": "Test uses Task.Delay(TimeSpan.FromSeconds(10)) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-06-19T07:04:36.9543103+00:00"
+    },
+    {
+      "hash": "fd99881f852f9a13",
+      "ruleId": "SW003",
+      "filePath": "tests/Aspire.Hosting.LocalStack.Unit.Tests/CDK/CdkBootstrapManagerTests.cs",
+      "lineNumber": 221,
+      "codeSnippet": "catch (IOException)\n        {\n            // Ignore cleanup errors to prevent test failures\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-06-19T07:04:36.9543234+00:00"
+    },
+    {
+      "hash": "4c35a49db0e77e84",
+      "ruleId": "SW002",
+      "filePath": "tests/Aspire.Hosting.LocalStack.Unit.Tests/Container/LocalStackContainerOptionsTests.cs",
+      "lineNumber": 1,
+      "codeSnippet": "#pragma warning disable S4143",
+      "message": "#pragma warning disable for warnings S4143 without matching restore in same scope",
+      "baselinedAt": "2026-06-19T07:04:36.9543257+00:00"
+    }
+  ]
+}

--- a/.slopwatch/config.json.example
+++ b/.slopwatch/config.json.example
@@ -1,0 +1,10 @@
+{
+  "suppressions": [
+    {
+      "ruleId": "SW002",
+      "pattern": "**/Generated/**",
+      "justification": "Generated code from protobuf/gRPC compiler - cannot be modified"
+    }
+  ],
+  "globalSuppressions": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,200 @@
+# Agent Instructions
+
+Operating rules for LLM/code agents working in this repository.
+
+## Communication Style
+
+- Be direct, practical, and clear.
+- Challenge decisions when needed; do not yes-person your way into bad architecture.
+- Prefer small correct changes over broad refactors.
+- Deniz communicates in Turkish and English interchangeably; respond in the language that best matches the current message.
+
+## Approval Gate
+
+### Do Not Without Explicit Approval
+
+- Start coding a new feature.
+- Refactor production code.
+- Modify build system behavior.
+- Change CI/CD pipelines.
+- Run deployment, publish, or package-release commands.
+- Commit, amend, push, or create a PR.
+
+Approval phrases include `go`, `apply`, `proceed`, `basla`, and `yap`.
+
+### Allowed Without Additional Approval
+
+- Documentation-only edits.
+- Broken internal link fixes.
+- Minor comment improvements that do not change behavior.
+- Read-only discovery commands and dry-run checks.
+
+### Before Any Commit
+
+Present a concise change summary and proposed Conventional Commit message, then ask for approval.
+
+Commit messages must use `feat`, `fix`, `docs`, `test`, `refactor`, `build`, `ci`, or `chore`. Do not add AI attribution trailers.
+
+## Project Context
+
+This repository builds `LocalStack.Aspire.Hosting`, a NuGet package in the `Aspire.Hosting.LocalStack` namespace.
+
+Keep this file lightweight. Read change-prone project facts from their source files instead of copying them here:
+
+- SDK and test runner: `global.json`
+- Target frameworks, analyzers, and Central Package Management: `Directory.Build.props`
+- Package versions: `Directory.Packages.props`
+- Package metadata and project references: project files under `src/`, `tests/`, and `playground/`
+- Runtime behavior: source code and tests first, then README/docs
+
+Repository layout for onboarding:
+
+- `src/`: package source
+- `tests/`: unit and integration tests
+- `playground/`: sample AppHosts and workloads
+- `docs/`: project documentation
+- `docs/agents/`: agent-facing guidance and known notes
+
+## Docs-First Workflow
+
+Before non-trivial work, inspect the relevant docs and code. For runtime behavior, code wins over docs.
+
+Recommended reading order:
+
+1. `README.md`
+2. `docs/CONFIGURATION.md`
+3. `AGENTS.md`
+4. `docs/agents/README.md`
+5. The relevant source or test file
+
+Change hygiene:
+
+- Update docs when behavior, topology, package support, or harness expectations change.
+- Prefer consolidation over new docs when an existing doc is the natural home.
+- Research docs must include a date.
+- Code comments and XML docs must be self-contained; do not reference specs, plans, phases, or external file paths from code comments.
+
+## Quality Notes
+
+- Use the standard .NET restore/build/test flow appropriate to the files changed.
+- Integration tests require Docker and LocalStack-compatible runtime conditions.
+- Package versions live in `Directory.Packages.props`; do not hand-edit package versions into individual project files.
+- Strict analyzers and warnings-as-errors are enabled through shared project configuration.
+- Documentation-only changes do not require build/test unless they add or change commands that should be validated.
+- If Slopwatch is available after LLM-authored code, project, or test changes, run:
+
+```powershell
+slopwatch analyze --fail-on warning --exclude "external/**,artifacts/**,**/bin/**,**/obj/**"
+```
+
+## Harness Portability
+
+- `AGENTS.md` is the canonical repository contract.
+- `CLAUDE.md` stays relay-only and points to `AGENTS.md`.
+- `.github/copilot-instructions.md` stays relay-only and points to `AGENTS.md`.
+- Harness-specific skill files are adapters, not policy sources.
+- Canonical project skill content lives in `docs/agents/skills/aspire-source-navigation.md`.
+- This repo maintains native adapters under `.claude/skills/`, `.opencode/skills/`, and `.github/skills/`.
+- Do not create `.vscode` skill folders. GitHub Copilot Agent Skills also support `.agents/skills/`, but this repo intentionally does not maintain that extra adapter location.
+- Never commit secrets, OAuth tokens, personal machine paths, or local MCP config.
+
+OpenCode loads project skills when the session starts. After changing `.opencode/skills/**`, tell the user to restart OpenCode if they need the new skill active in the running UI.
+
+## Source Navigation For Aspire Compatibility
+
+Use `aspire-source-navigation` before changing or reviewing work that depends on Aspire hosting internals, `Aspire.Hosting.AWS`, LocalStack.Client behavior, package version alignment, or source-level compatibility.
+
+The skill must resolve package versions from `Directory.Packages.props`, then cross-check those versions against local upstream checkouts under `external/`. Do not silently use upstream default branches for compatibility-sensitive checks.
+
+Preferred local checkout layout uses refs derived from package versions and verified upstream tags/releases:
+
+```text
+external/aspire/{ref}/
+external/aws-integrations/{ref}/
+external/localstack-dotnet-client/{ref}/
+```
+
+The `external/` tree is local-only and ignored by git. GitHub MCP is allowed for tag/ref discovery, release verification, or fallback reads when local source is unavailable; it is not the default source-reading path.
+
+Official Microsoft Aspire skills may describe newer Aspire versions than this repo uses. Verify API shape against `Directory.Packages.props` and local upstream source before applying newer guidance.
+
+## Skills Used In This Project
+
+Skills encode workflow discipline and retrieval-led reasoning. Use exact installed skill names when invoking skills.
+
+### Always Active
+
+| Skill | Trigger |
+| --- | --- |
+| `using-superpowers` | Start of every session; establishes skill usage rules |
+| `brainstorming` | Feature, behavior, design, or refactor work before implementation |
+| `writing-plans` | Multi-step implementation planning after design approval |
+| `test-driven-development` | Production bugfixes and feature implementation |
+| `systematic-debugging` | Bugs, test failures, unexpected behavior, flaky behavior |
+| `verification-before-completion` | Before claiming work is complete or passing |
+| `requesting-code-review` / `receiving-code-review` | Review workflows and review feedback |
+
+### .NET And Package Work
+
+| Skill | Trigger |
+| --- | --- |
+| `dotnet-project-structure` | Solution, project, target framework, SDK, or shared MSBuild changes |
+| `package-management` | NuGet package additions, removals, or version changes |
+| `modern-csharp-coding-standards` | C# production or test code changes |
+| `type-design-performance` | Public type shape, collections, allocation-sensitive choices |
+| `csharp-concurrency-patterns` | Async, synchronization, delays, channels, task scheduling |
+| `dependency-injection-patterns` | DI registrations or service composition |
+| `microsoft-extensions-configuration` | Options/configuration binding or validation |
+| `serialization` | JSON or other serialization contract changes |
+| `dotnet-slopwatch` | After LLM-authored code, project, or test changes when available |
+
+### Aspire Routing
+
+| Trigger | Preferred route |
+| --- | --- |
+| Core package work under `src/` | `aspire-source-navigation` plus relevant .NET skill |
+| Integration tests under `tests/` | `aspire-source-navigation`; add `aspire-integration-testing` for `DistributedApplicationTestingBuilder` patterns and adapt examples to this repo's test framework |
+| Package version compatibility in `Directory.Packages.props` | `aspire-source-navigation` plus `package-management` |
+| Explicit AppHost-to-service configuration, `WithEnvironment`, `LocalStack__*`, fallback behavior | `aspire-configuration` plus `aspire-source-navigation` |
+| Playground ServiceDefaults or observability defaults | `aspire-service-defaults` |
+| AppHost start/stop/wait/logs/dashboard/deployment workflows | Official Microsoft `aspire`, `aspire-orchestration`, `aspire-monitoring`, or `aspire-deployment` if available |
+| New Aspire skeleton creation | Official Microsoft `aspire-init` if available; normally out of scope here |
+| AppHost wiring/scaffold/resource graph work | Official Microsoft `aspireify` if available; verify against this repo's package versions |
+
+### Specialist Agents
+
+- Use `dotnet-concurrency-specialist` for racy tests, deadlocks, or async timing bugs.
+- Use `dotnet-performance-analyst` only when measured performance data exists.
+- Use `explore` for broad codebase discovery across many files when the harness provides it; otherwise use local search tools.
+- Use `general` for bounded multi-step research tasks when the harness provides it; otherwise keep the research in the main session.
+
+### Out Of Scope Unless Explicitly Needed
+
+- Akka.NET skills and agents.
+- Email/MJML/Mailpit skills.
+- EF Core/database performance skills unless a real persistence layer is added.
+- Playwright skills unless browser UI tests are added.
+- Marketplace publishing skills.
+
+## Semantic Code Navigation
+
+When Rider MCP tools are available, prefer semantic tools for C# symbol questions:
+
+- Declarations and symbol meaning: `search_symbol`, `get_symbol_info`
+- File analysis: `get_file_problems`
+- Solution/project shape: `get_solution_projects`, `get_project_dependencies`
+- Renames and type moves: semantic refactoring tools when approval allows mutation
+
+Use text search for docs, manifests, comments, literal strings, and when Rider is unavailable.
+
+Agent-facing known notes live in `docs/agents/KNOWN_ISSUES.md`. Treat them as triage hints, not permission to refactor unrelated code.
+
+## When Deniz Asks For A Review
+
+Use a code-review mindset. Findings come first, ordered by severity, with file and line references when possible. If there are no findings, say so and mention residual risk or testing gaps.
+
+For interactive reviews, offer options for each issue:
+
+- A recommended option with effort, risk, impact, and maintenance burden.
+- One or two alternatives, including doing nothing when reasonable.
+- Ask Deniz to confirm before large changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+The canonical agent contract for Claude Code (claude.ai/code) and other LLM assistants lives in [AGENTS.md](AGENTS.md).
+
+Read [AGENTS.md](AGENTS.md) first.
+
+This file intentionally stays as a relay only.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,13 +16,13 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.0"/>
     <PackageVersion Include="Aspire.Hosting.AWS" Version="9.3.0"/>
     <!-- aws packages -->
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.3.6"/>
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.10.4"/>
-    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.8"/>
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.10"/>
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.15.1"/>
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.17"/>
-    <PackageVersion Include="AWS.Messaging" Version="1.0.2"/>
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9.6"/>
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.21.6"/>
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.3.7"/>
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.3.7"/>
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.25.2"/>
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.10"/>
+    <PackageVersion Include="AWS.Messaging" Version="1.3.0"/>
     <PackageVersion Include="AWS.Messaging.Telemetry.OpenTelemetry" Version="1.0.0"/>
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.0"/>
     <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3"/>
@@ -36,14 +36,15 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0"/>
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.1.0"/>
     <!-- opentelemetry packages -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0"/>
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.16.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.16.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1"/>
     <!-- third-party packages -->
+    <PackageVersion Include="MessagePack" Version="2.5.301"/>
     <PackageVersion Include="Net.Codecrete.QrCodeGenerator" Version="2.0.7"/>
     <PackageVersion Include="SkiaSharp" Version="3.119.1"/>
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1"/>

--- a/docs/agents/KNOWN_ISSUES.md
+++ b/docs/agents/KNOWN_ISSUES.md
@@ -9,3 +9,4 @@ These notes are hints for agents during triage and review. They are not permissi
 - `playground/lambda/LocalStack.Lambda.UrlShortener/S3UrlService.cs` has an `AWS_REGION ` environment lookup with a trailing space.
 - Some AWS integration logic may depend on version-sensitive type-name string matching.
 - Lambda integration tests contain fixed-delay waits for async SQS/event-source behavior.
+- `Aspire.Hosting.LocalStack.csproj` temporarily has direct `AWSSDK.Core` and `MessagePack` package references to avoid NuGet vulnerability restore failures. Remove these pins when the real upstream dependency chain is fixed; this NuGet package should not permanently expose extra direct dependencies, especially `MessagePack`.

--- a/docs/agents/KNOWN_ISSUES.md
+++ b/docs/agents/KNOWN_ISSUES.md
@@ -1,0 +1,11 @@
+# Agent Known Notes
+
+Date: 2026-06-18
+
+These notes are hints for agents during triage and review. They are not permission to refactor unrelated code.
+
+- `.github/PULL_REQUEST_TEMPLATE.md` may mention older Aspire/.NET wording.
+- `docs/CONFIGURATION.md` can drift from code defaults such as the LocalStack image version.
+- `playground/lambda/LocalStack.Lambda.UrlShortener/S3UrlService.cs` has an `AWS_REGION ` environment lookup with a trailing space.
+- Some AWS integration logic may depend on version-sensitive type-name string matching.
+- Lambda integration tests contain fixed-delay waits for async SQS/event-source behavior.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,55 @@
+# Agent Harness Guide
+
+Date: 2026-06-18
+
+This directory contains repository-specific guidance for AI coding agents.
+
+## Source Of Truth
+
+`AGENTS.md` is the canonical always-on contract. Harness-specific files relay to it or expose native discovery points, but they do not own policy.
+
+| File | Purpose |
+| --- | --- |
+| `AGENTS.md` | Canonical repository contract |
+| `CLAUDE.md` | Claude Code relay to `AGENTS.md` |
+| `.github/copilot-instructions.md` | GitHub Copilot relay to `AGENTS.md` |
+| `docs/agents/KNOWN_ISSUES.md` | Agent-facing known notes and triage hints |
+| `docs/agents/skills/aspire-source-navigation.md` | Canonical project skill content |
+| `.claude/skills/aspire-source-navigation/SKILL.md` | Claude Code native skill relay |
+| `.opencode/skills/aspire-source-navigation/SKILL.md` | OpenCode native skill relay |
+| `.github/skills/aspire-source-navigation/SKILL.md` | GitHub Copilot / VS Code Agent Skills relay |
+
+## Harness Notes
+
+Claude Code discovers project skills under `.claude/skills/{skill-name}/SKILL.md`.
+
+OpenCode discovers project skills under `.opencode/skills/{skill-name}/SKILL.md`. OpenCode loads skill files at session start, so restart OpenCode after changing `.opencode/skills/**`; the current running session will not discover newly added project skills.
+
+GitHub Copilot in VS Code supports repository instructions through `.github/copilot-instructions.md` and Agent Skills under `.github/skills/`.
+
+Do not create `.vscode` skill folders. That is not a canonical Agent Skills location for this repository.
+
+## Skill Maintenance
+
+The canonical skill body lives in `docs/agents/skills/aspire-source-navigation.md`. Native `SKILL.md` files should stay small and point back to the canonical document.
+
+When changing the skill:
+
+1. Update the canonical document first.
+2. Update native relay files only if the trigger description or canonical path changes.
+3. Verify no relay copied the full canonical body.
+4. Verify OpenCode-compatible frontmatter exists in `.opencode/skills/aspire-source-navigation/SKILL.md`.
+5. Tell OpenCode users to restart their session if they need the updated skill loaded.
+6. After restart, verify the OpenCode skill can be loaded with `skill aspire-source-navigation`.
+
+## Local Upstream Sources
+
+Source-level Aspire compatibility checks should prefer local upstream checkouts:
+
+```text
+external/aspire/{ref}/
+external/aws-integrations/{ref}/
+external/localstack-dotnet-client/{ref}/
+```
+
+Resolve `{ref}` from package versions in `Directory.Packages.props` and verified upstream tags/releases. The `external/` tree is ignored by git. Do not commit upstream clones.

--- a/docs/agents/skills/aspire-source-navigation.md
+++ b/docs/agents/skills/aspire-source-navigation.md
@@ -1,0 +1,78 @@
+---
+name: aspire-source-navigation
+description: Use when working on Aspire.Hosting.LocalStack source compatibility, Aspire/AWS/LocalStack package internals, Directory.Packages.props version bumps, or AddLocalStack/UseLocalStack/WithReference behavior.
+---
+
+# Aspire Source Navigation
+
+## Overview
+
+This repository maintains an Aspire hosting integration package. Compatibility-sensitive work depends on this repo's package versions and on matching upstream source checkouts, not on memory or upstream default branches.
+
+Use source evidence before editing compatibility-sensitive code. Keep this skill version-light: package versions and concrete refs belong in `Directory.Packages.props`, local `external/` checkouts, and the upstream repositories.
+
+## When To Use
+
+Use this skill for work involving:
+
+- `Aspire.Hosting` or `Aspire.Hosting.AWS` internals
+- LocalStack.Client behavior
+- `Directory.Packages.props` Aspire, AWS integration, or LocalStack client versions
+- `AddLocalStack`, `UseLocalStack`, `.WithReference(localstack)`, endpoint/configuration flow, manifest behavior, CloudFormation/CDK, Lambda, or AWS SDK wiring
+- String-based references to upstream AWS Aspire integration types
+- Reviews of Aspire hosting compatibility or package-version drift
+
+Do not use this skill for ordinary Markdown edits, general C# cleanup, or playground-only work that does not depend on Aspire/AWS/LocalStack internals.
+
+## Required Workflow
+
+1. Read `Directory.Packages.props` and identify the exact package versions involved.
+2. Map the packages to their upstream repositories: Aspire packages to `dotnet/aspire`, `Aspire.Hosting.AWS` to `aws/integrations-on-dotnet-aspire-for-aws`, and LocalStack packages to `localstack-dotnet/localstack-dotnet-client`.
+3. Check whether a matching local checkout exists under `external/`.
+4. Verify the local checkout's branch/tag/commit against the package version and upstream tags/releases before trusting it.
+5. If local source is missing or stale, report that explicitly. Use GitHub MCP only for tag/ref discovery, release verification, or targeted fallback reads.
+6. Search upstream source for the exact symbols, annotations, extension methods, and behavior involved in the task. Do not rely on pre-baked search terms.
+7. Cross-check this repository's implementation and tests against the verified upstream source.
+8. Report evidence with file paths and refs before recommending or making changes.
+
+## Local Checkout Layout
+
+Use this layout when local source is available:
+
+```text
+external/aspire/{ref}/
+external/aws-integrations/{ref}/
+external/localstack-dotnet-client/{ref}/
+```
+
+`{ref}` should be derived from the package version and verified against upstream tags/releases. The `external/` tree is ignored by git. Do not commit upstream source checkouts.
+
+## Official Aspire Skills Cross-Check
+
+Official Microsoft Aspire skills are useful for Aspire CLI and distributed application workflows, but they may describe newer Aspire versions than this repository uses. If official guidance conflicts with verified package source, prefer verified package source and call out the version mismatch.
+
+Use official skills when available for:
+
+| Task | Skill |
+| --- | --- |
+| AppHost lifecycle | `aspire` or `aspire-orchestration` |
+| Logs, dashboard, traces | `aspire-monitoring` |
+| AppHost scaffold/resource graph work | `aspireify` |
+| New skeleton creation | `aspire-init` |
+| Publish/deploy/destroy | `aspire-deployment`, approval-gated |
+
+Installed local skills can supplement this one:
+
+| Task | Skill |
+| --- | --- |
+| Explicit configuration and env vars | `aspire-configuration` |
+| Playground ServiceDefaults | `aspire-service-defaults` |
+| `DistributedApplicationTestingBuilder` patterns | `aspire-integration-testing`, adapted to this repo's test framework |
+
+## Common Mistakes
+
+- Do not use upstream default branches for compatibility-sensitive source checks.
+- Do not assume package versions map directly to semver git tags; verify the upstream tag/release scheme.
+- Do not copy examples from external testing guidance without adapting them to this repo's test framework.
+- Do not commit `external/` source checkouts.
+- Do not treat GitHub MCP as the default source-reading path when local source is available.

--- a/playground/provisioning/LocalStack.Provisioning.Frontend/Handlers/ChatMessageHandler.cs
+++ b/playground/provisioning/LocalStack.Provisioning.Frontend/Handlers/ChatMessageHandler.cs
@@ -2,7 +2,6 @@
 // Originally copied from https://github.com/aws/integrations-on-dotnet-aspire-for-aws
 // and adjusted for Aspire.Hosting.LocalStack. All rights reserved.
 
-#pragma warning disable CA1848 // Use the LoggerMessage delegates
 #pragma warning disable CA1812 // Mark members as static
 
 using System.Globalization;
@@ -16,7 +15,7 @@ namespace LocalStack.Provisioning.Frontend.Handlers;
 /// <summary>
 /// Handles ChatMessage messages from SQS queue and persists them to DynamoDB.
 /// </summary>
-internal sealed class ChatMessageHandler(IAmazonDynamoDB dynamoDbClient, IConfiguration configuration, ILogger<ChatMessageHandler> logger)
+internal sealed partial class ChatMessageHandler(IAmazonDynamoDB dynamoDbClient, IConfiguration configuration, ILogger<ChatMessageHandler> logger)
     : IMessageHandler<ChatMessage>
 {
     public async Task<MessageProcessStatus> HandleAsync(
@@ -25,7 +24,7 @@ internal sealed class ChatMessageHandler(IAmazonDynamoDB dynamoDbClient, IConfig
     {
         ArgumentNullException.ThrowIfNull(messageEnvelope);
 
-        logger.LogInformation("Processing chat message: {Message} for recipient: {Recipient}",
+        LogProcessingChatMessage(logger,
             messageEnvelope.Message.Message,
             messageEnvelope.Message.Recipient);
 
@@ -55,19 +54,47 @@ internal sealed class ChatMessageHandler(IAmazonDynamoDB dynamoDbClient, IConfig
 
             await dynamoDbClient.PutItemAsync(putItemRequest, token).ConfigureAwait(false);
 
-            logger.LogInformation("Successfully stored chat message with ID {MessageId} in DynamoDB table {TableName}", messageId, tableName);
+            LogStoredChatMessage(logger, messageId, tableName);
 
             return MessageProcessStatus.Success();
         }
         catch (AmazonDynamoDBException ex)
         {
-            logger.LogError(ex, "DynamoDB error while processing chat message: {ErrorCode} - {ErrorMessage}", ex.ErrorCode, ex.Message);
+            LogDynamoDbError(logger, ex, ex.ErrorCode, ex.Message);
             return MessageProcessStatus.Failed();
         }
         catch (OperationCanceledException ex)
         {
-            logger.LogWarning(ex, "Chat message processing was cancelled");
+            LogChatMessageProcessingCancelled(logger, ex);
             return MessageProcessStatus.Failed();
         }
     }
+
+    [LoggerMessage(
+        EventId = 1,
+        EventName = "ProcessingChatMessage",
+        Level = LogLevel.Information,
+        Message = "Processing chat message: {Message} for recipient: {Recipient}")]
+    private static partial void LogProcessingChatMessage(ILogger logger, string? message, string? recipient);
+
+    [LoggerMessage(
+        EventId = 2,
+        EventName = "StoredChatMessage",
+        Level = LogLevel.Information,
+        Message = "Successfully stored chat message with ID {MessageId} in DynamoDB table {TableName}")]
+    private static partial void LogStoredChatMessage(ILogger logger, string messageId, string tableName);
+
+    [LoggerMessage(
+        EventId = 3,
+        EventName = "DynamoDbError",
+        Level = LogLevel.Error,
+        Message = "DynamoDB error while processing chat message: {ErrorCode} - {ErrorMessage}")]
+    private static partial void LogDynamoDbError(ILogger logger, Exception exception, string? errorCode, string errorMessage);
+
+    [LoggerMessage(
+        EventId = 4,
+        EventName = "ChatMessageProcessingCancelled",
+        Level = LogLevel.Warning,
+        Message = "Chat message processing was cancelled")]
+    private static partial void LogChatMessageProcessingCancelled(ILogger logger, Exception exception);
 }

--- a/src/Aspire.Hosting.LocalStack/Aspire.Hosting.LocalStack.csproj
+++ b/src/Aspire.Hosting.LocalStack/Aspire.Hosting.LocalStack.csproj
@@ -20,7 +20,9 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting"/>
     <PackageReference Include="Aspire.Hosting.AWS"/>
+    <PackageReference Include="AWSSDK.Core"/>
     <PackageReference Include="LocalStack.Client"/>
+    <PackageReference Include="MessagePack"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 📝 Description

**What does this PR do?**
Adds lightweight, cross-harness agent guidance for Claude Code, OpenCode, and GitHub Copilot without copying change-prone project facts into always-on instructions.

- Adds `AGENTS.md` as the canonical lightweight agent contract and router.
- Adds native `aspire-source-navigation` skill relays for Claude Code, OpenCode, and GitHub Copilot.
- Documents the canonical Aspire source-navigation workflow under `docs/agents/` using `Directory.Packages.props` + `external/` source cross-checks instead of hard-coded package refs.
- Adds agent-facing known notes under `docs/agents/KNOWN_ISSUES.md`.

**Related Issue(s):**

- N/A

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🧹 Code cleanup/refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## 🎯 Aspire Compatibility

- [x] N/A - documentation-only, no runtime Aspire behavior changes
- [ ] Compatible with .NET Aspire 9.x
- [ ] Supports both .NET 8.0 and .NET 9.0
- [ ] Follows Aspire.Hosting.AWS patterns
- [ ] Works with existing AWS integrations

## 🧪 Testing

**How has this been tested?**

- [x] Verified active agent docs contain no hard-coded package/ref/search-target tables
- [x] Verified `aspire-source-navigation` requires `Directory.Packages.props` + `external/` checkout cross-checks
- [x] Verified native skill relays are thin and point to the canonical skill document
- [x] Ran `git diff master...HEAD --check`
- [ ] Unit tests added/updated (N/A - docs only)
- [ ] Integration tests added/updated (N/A - docs only)

**Test Environment:**

- LocalStack Version: N/A
- .NET Aspire Version: N/A
- .NET Versions Tested: N/A
- Operating Systems: Windows local repo

## 📚 Documentation

- [x] README.md updated (not needed)
- [x] Agent documentation added under `docs/agents/`
- [x] Harness relays added for Claude Code, OpenCode, and GitHub Copilot
- [x] Breaking changes documented (N/A - docs only)

## ✅ Code Quality Checklist

- [x] Documentation keeps change-prone facts in source files such as `Directory.Packages.props`, `Directory.Build.props`, and project files
- [x] No product code changed
- [x] No build, package, test, or CI behavior changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## 🔍 Additional Notes

**Breaking Changes:**
None.

**Performance Impact:**
None.

**Dependencies:**
None.

## 🎯 Reviewer Focus Areas

**Please pay special attention to:**

- [x] Documentation completeness
- [x] Agent harness portability
- [x] Aspire source-navigation workflow staying version-light
- [x] OpenCode restart/discovery note
- [x] No `.vscode` skill folder guidance

## 📸 Screenshots/Examples

N/A - documentation-only PR.

---

By submitting this pull request, I confirm that:

- [x] I have read and agree to the project's [Code of Conduct](.github/CODE_OF_CONDUCT.md)
- [x] I understand that this contribution may be subject to the [.NET Foundation CLA](.github/CONTRIBUTING.md)
- [x] My contribution is licensed under the same terms as the project (MIT License)